### PR TITLE
fix: ensure initial matching when -input= option is provided

### DIFF
--- a/denops/fall/processor/match.ts
+++ b/denops/fall/processor/match.ts
@@ -50,7 +50,9 @@ export class MatchProcessor<T extends Detail> implements Disposable {
     this.#chunkInterval = options.chunkInterval ?? CHUNK_INTERVAL;
     this.#incremental = options.incremental ?? false;
     this.#items = options.initialItems?.slice() ?? [];
-    this.#previousQuery = options.initialQuery;
+    // Do not set initialQuery to #previousQuery to ensure the first matching
+    // is executed when the initial query is provided via -input= option.
+    this.#previousQuery = undefined;
   }
 
   get #matcher(): Matcher<T> {


### PR DESCRIPTION
## Summary
- Fixes an issue where the first matching was not executed when using the `-input=` option
- The root cause was that `initialQuery` was being set to `#previousQuery`, which prevented the matching logic from detecting a query change

## Changes
- Set `#previousQuery` to `undefined` on initialization instead of `initialQuery`
- Added comment explaining why this is necessary for the `-input=` option to work correctly

## Test plan
- [ ] Verify that providing `-input=` option triggers initial matching
- [ ] Verify that normal operation without `-input=` still works as expected

## Notes
Recreated from main branch to ensure clean CI runs.